### PR TITLE
add sampling ratio flag to operation result collection

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -283,6 +283,11 @@ var ioFlags = []cli.Flag{
 		Usage:  "Add user tag to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --tag foo=bar --tag randomValue=rand:1024.",
 		Hidden: true,
 	},
+	cli.IntFlag{
+		Name:  "sampling-ratio",
+		Value: 1,
+		Usage: "Sampling ratio for collector",
+	},
 }
 
 func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
@@ -312,6 +317,7 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		Location:      ctx.String("region"),
 		PutOpts:       putOpts(ctx),
 		DiscardOutput: ctx.Bool("stress"),
+		SamplingRatio: ctx.Int("sampling-ratio"),
 		ExtraOut:      extra,
 		RpsLimiter:    rpsLimiter,
 		Transport:     clientTransport(ctx),

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -286,7 +286,7 @@ var ioFlags = []cli.Flag{
 	cli.IntFlag{
 		Name:  "sampling-ratio",
 		Value: 1,
-		Usage: "Sampling ratio for collector",
+		Usage: "Sampling ratio for collector. Sampling ration of 100 means 1 out of every 100 requests would be sampled.",
 	},
 }
 

--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -102,6 +102,9 @@ type Common struct {
 
 	// Transport used.
 	Transport http.RoundTripper
+
+	// Sampling rate for collector.
+	SamplingRatio int
 }
 
 const (
@@ -255,7 +258,7 @@ func (c *Common) addCollector() {
 	if c.DiscardOutput {
 		c.Collector = NewNullCollector()
 	} else {
-		c.Collector = NewCollector()
+		c.Collector = NewCollector(c.SamplingRatio)
 	}
 	c.Collector.extra = c.ExtraOut
 }

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -88,7 +88,7 @@ func (d *Delete) Prepare(ctx context.Context) error {
 			return (fmt.Errorf("no objects found for bucket %s", d.Bucket))
 		}
 		done()
-		d.Collector = NewCollector()
+		d.Collector = NewCollector(d.SamplingRatio)
 
 		// Shuffle objects.
 		// Benchmark will pick from slice in order.


### PR DESCRIPTION
tested with simple warp stat with sampling ratio 10 vs 1

```
$ warp analyze warp-stat-2025-01-27\[142925\]-3SDs.csv.zst
5783 operations loaded... Done!

----------------------------------------
Operation: STAT. Concurrency: 20
* Average: 193.20 obj/s

Throughput, split into 29 x 1s:
 * Fastest: 196.92 obj/s
 * 50% Median: 193.15 obj/s
 * Slowest: 189.00 obj/s

$ warp analyze warp-stat-2025-01-27\[143239\]-aqzO.csv.zst
585 operations loaded... Done!

----------------------------------------
Operation: STAT. Concurrency: 20
* Average: 19.50 obj/s

Throughput, split into 21 x 1s:
 * Fastest: 20.00 obj/s
 * 50% Median: 19.60 obj/s
 * Slowest: 17.92 obj/s
```